### PR TITLE
fix shodai article page counts

### DIFF
--- a/app/2024/articleInfoList.tsx
+++ b/app/2024/articleInfoList.tsx
@@ -149,7 +149,7 @@ export const articleInfoList: ArticleInfo[] = [
   {
     id: 'shodaiSato',
     component: <ShodaiSato/>,
-    totalPage: 3,
+    totalPage: 4,
     title: '愛と金',
     description: 'あるいは信頼と信用',
     atogaki: '未定',


### PR DESCRIPTION
### やったこと
しょうだいさんの記事のページ数が誤っていたので修正

### 懸念点
この修正を行う場合、合計81ページになるらしくViewerの右側サイドバーの表示が以下のようになっている。。
![Screenshot 2024-11-28 at 23-01-08 サイバーメタルチンピラ](https://github.com/user-attachments/assets/7786ddef-c9df-41e4-ac9b-c501c2b8e5f2)
